### PR TITLE
fixes undefined constant exception with higher versions of php

### DIFF
--- a/src/pg/constants/Config.php
+++ b/src/pg/constants/Config.php
@@ -25,7 +25,7 @@
         /**
          * @var string
          */
-        static $monologLogfile = PROJECT . '/logs/app.log';
+        static $monologLogfile = __dir__ . '/logs/app.log';
 
         /**
          * This holds unique uuid v4


### PR DESCRIPTION
The SDK throws constant undefined exception with new PHP version 7.*